### PR TITLE
Fixing contributing link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ https://gist.github.com/kevinelliott/0726211d17020a6abc1f
 
 ## Contribute
 
-Contributions are most welcome, try to adhere to the [contribution guidelines](http://github.com/iCHAIT/awesome-mac/contributing.md)
+Contributions are most welcome, try to adhere to the [contribution guidelines](contributing.md)
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
Link was currently 404, changed it to a relative link instead per https://help.github.com/articles/relative-links-in-readmes/.