### PR TITLE
TheUnarchiver: fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@
 - [Mackup](https://github.com/lra/mackup) - Keep your application settings in sync. ![Open-Source Software](media/oss.png)
 - [Monodraw](http://monodraw.helftone.com/) - A powerful ASCII art editor.
 - [Subtitles](http://subtitlesapp.com/) - Automatically downloads subtitles for your movies and TV shows.
-- [TheUnarchiver](https://itunes.apple.com/app/the-unarchiver/id425424353) - Unarchive many different kinds of archive files. ![Open-Source Software](media/oss.png)
+- [TheUnarchiver](http://wakaba.c3.cx/s/apps/unarchiver.html) - Unarchive many different kinds of archive files. ![Open-Source Software](media/oss.png)
 
 
 ### Others

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@
 - [Mackup](https://github.com/lra/mackup) - Keep your application settings in sync. ![Open-Source Software](media/oss.png)
 - [Monodraw](http://monodraw.helftone.com/) - A powerful ASCII art editor.
 - [Subtitles](http://subtitlesapp.com/) - Automatically downloads subtitles for your movies and TV shows.
-- [TheUnarchiver](https://itunes.apple.com/app/the-unarchiver/id425424353) - Unarchive many different kinds of archive files.
+- [TheUnarchiver](https://itunes.apple.com/app/the-unarchiver/id425424353) - Unarchive many different kinds of archive files. ![Open-Source Software](media/oss.png)
 
 
 ### Others

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@
 - [Mackup](https://github.com/lra/mackup) - Keep your application settings in sync. ![Open-Source Software](media/oss.png)
 - [Monodraw](http://monodraw.helftone.com/) - A powerful ASCII art editor.
 - [Subtitles](http://subtitlesapp.com/) - Automatically downloads subtitles for your movies and TV shows.
-- [TheUnarchiver](https://itunes.apple.com/app/the-unarchiver/id425424353) - An app that unarchive many different kinds of archive files.
+- [TheUnarchiver](https://itunes.apple.com/app/the-unarchiver/id425424353) - Unarchive many different kinds of archive files.
 
 
 ### Others


### PR DESCRIPTION
As it were, it should’ve read either:

+ An app that unarchive**s** many different kinds of archive files.
+ An app **to** unarchive many different kinds of archive files.

Decided to follow neither and shorten the sentence. No need to say it’s an app (that’s what the repo is form), and the others do not follow that convention, anyway.

Also adds the OSS badge.