### PR TITLE
Use reference style links in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A curated list of awesome applications, softwares, tools and shiny things for OS X.
 
-> *Items marked with ![Open-Source Software](media/oss.png) are open-source software.*
+> *Items marked with ![Open-Source Software][OSS Icon] are open-source software.*
 
 ## Table of Contents
 
@@ -22,39 +22,39 @@
 ### Chat Clients
 
 
-- [ChitChat](https://github.com/stonesam92/ChitChat) - A native Mac app wrapper for WhatsApp Web. ![Open-Source Software](media/oss.png)
-- [LimeChat](http://limechat.net/mac/) - Instant messaging application. ![Open-Source Software](media/oss.png)
-- [Messenger for Desktop](http://messengerfordesktop.com/) - An app for Facebook messenger. ![Open-Source Software](media/oss.png)
-- [Textual 5](https://www.codeux.com/textual/) - An Internet Relay Chat (IRC) client. ![Open-Source Software](media/oss.png)
+- [ChitChat](https://github.com/stonesam92/ChitChat) - A native Mac app wrapper for WhatsApp Web. ![Open-Source Software][OSS Icon]
+- [LimeChat](http://limechat.net/mac/) - Instant messaging application. ![Open-Source Software][OSS Icon]
+- [Messenger for Desktop](http://messengerfordesktop.com/) - An app for Facebook messenger. ![Open-Source Software][OSS Icon]
+- [Textual 5](https://www.codeux.com/textual/) - An Internet Relay Chat (IRC) client. ![Open-Source Software][OSS Icon]
 
 
 ### Developers
 
 - [Base 2](http://menial.co.uk/base/) - A GUI for managing SQLite databases.
-- [Cakebrew](https://github.com/brunophilipe/Cakebrew) - The Homebrew GUI App. ![Open-Source Software](media/oss.png)
-- [Color-Picker-Pro](https://github.com/oscardelben/Color-Picker-Pro) - A Color Detection Tool. ![Open-Source Software](media/oss.png)
+- [Cakebrew](https://github.com/brunophilipe/Cakebrew) - The Homebrew GUI App. ![Open-Source Software][OSS Icon]
+- [Color-Picker-Pro](https://github.com/oscardelben/Color-Picker-Pro) - A Color Detection Tool. ![Open-Source Software][OSS Icon]
 - [Dash](https://kapeli.com/dash) - An API Documentation Browser and Code Snippet Manager.
 - [Github Desktop](https://mac.github.com/) - A GUI for using Github.
-- [Gitup](https://github.com/git-up/GitUp) - A simple but powerful Git OS X app. ![Open-Source Software](media/oss.png)
-- [ImageOptim](https://imageoptim.com/) - Makes images take up less disk space and load faster. ![Open-Source Software](media/oss.png)
+- [Gitup](https://github.com/git-up/GitUp) - A simple but powerful Git OS X app. ![Open-Source Software][OSS Icon]
+- [ImageOptim](https://imageoptim.com/) - Makes images take up less disk space and load faster. ![Open-Source Software][OSS Icon]
 - [Paw](https://luckymarmot.com/paw) - The ultimate REST client for Mac.
 - [PSequel](http://www.psequel.com/) - A PostgreSQL GUI tool.
 - [Sequel Pro](http://www.sequelpro.com/) - A MySQL database manager.
 - [SourceTree](https://www.sourcetreeapp.com/) - A free Git & Mercurial client.
 - [Tower](http://www.git-tower.com/) - The most powerful Git client.
-- [Unused](https://github.com/jeffhodnett/Unused) - An app for checking Xcode projects for unused resources. ![Open-Source Software](media/oss.png)
-- [WWDC](https://github.com/insidegui/WWDC) - The WWDC app. ![Open-Source Software](media/oss.png)
-- [Zsh](http://www.zsh.org/) -  A powerful command line shell. ![Open-Source Software](media/oss.png)
+- [Unused](https://github.com/jeffhodnett/Unused) - An app for checking Xcode projects for unused resources. ![Open-Source Software][OSS Icon]
+- [WWDC](https://github.com/insidegui/WWDC) - The WWDC app. ![Open-Source Software][OSS Icon]
+- [Zsh](http://www.zsh.org/) -  A powerful command line shell. ![Open-Source Software][OSS Icon]
 
 
 ### Editors
 
-- [Atom](https://atom.io/) - The hackable text editor. ![Open-Source Software](media/oss.png)
-- [Brackets](http://brackets.io/) - A modern text editor that understands web design. ![Open-Source Software](media/oss.png)
-- [Light Table](https://github.com/LightTable/LightTable) - A customizable editor with REPL support for Clojure, JavaScript, Python and others. ![Open-Source Software](media/oss.png)
-- [Macvim](https://github.com/b4winckler/macvim) - Vim, the text editor. ![Open-Source Software](media/oss.png)
+- [Atom](https://atom.io/) - The hackable text editor. ![Open-Source Software][OSS Icon]
+- [Brackets](http://brackets.io/) - A modern text editor that understands web design. ![Open-Source Software][OSS Icon]
+- [Light Table](https://github.com/LightTable/LightTable) - A customizable editor with REPL support for Clojure, JavaScript, Python and others. ![Open-Source Software][OSS Icon]
+- [Macvim](https://github.com/b4winckler/macvim) - Vim, the text editor. ![Open-Source Software][OSS Icon]
 - [Sublime Text 3](http://www.sublimetext.com/) - The sophisticated text editor.
-- [Textmate](https://macromates.com/) - A graphical text editor. ![Open-Source Software](media/oss.png)
+- [Textmate](https://macromates.com/) - A graphical text editor. ![Open-Source Software][OSS Icon]
 - [Visual Studio Code](https://code.visualstudio.com/) - Build and debug modern web and cloud applications.
 
 
@@ -65,60 +65,60 @@
 
 
 ### Games
-- [OpenEmu](http://openemu.org/) - Multiple Video Game System. ![Open-Source Software](media/oss.png)
-- [Screentendo](https://github.com/AaronRandall/Screentendo) - Turn your screen into a playable level of Mario. ![Open-Source Software](media/oss.png)
-- [stockfish-mac](https://github.com/daylen/stockfish-mac) - Beautiful, powerful chess application. ![Open-Source Software](media/oss.png)
+- [OpenEmu](http://openemu.org/) - Multiple Video Game System. ![Open-Source Software][OSS Icon]
+- [Screentendo](https://github.com/AaronRandall/Screentendo) - Turn your screen into a playable level of Mario. ![Open-Source Software][OSS Icon]
+- [stockfish-mac](https://github.com/daylen/stockfish-mac) - Beautiful, powerful chess application. ![Open-Source Software][OSS Icon]
 
 
 ### Productivity
 
 - [Alfred](http://www.alfredapp.com/) - Boosts your efficiency and productivity.
-- [ClipMenu](http://www.clipmenu.com/) - ClipBoard History Manager. ![Open-Source Software](media/oss.png)
+- [ClipMenu](http://www.clipmenu.com/) - ClipBoard History Manager. ![Open-Source Software][OSS Icon]
 - [CloudClip](https://itunes.apple.com/app/cloudclip/id563356503) - Sync your clipboard between your Mac and your iOS devices.
 - [HyperDock](https://bahoom.com/hyperdock/) - Select individual application window.
-- [Quicksilver](http://qsapp.com/) - Control your Mac quickly and elegantly. ![Open-Source Software](media/oss.png)
-- [Spectacle](http://spectacleapp.com/) - Easily organize windows without using a mouse. ![Open-Source Software](media/oss.png)
+- [Quicksilver](http://qsapp.com/) - Control your Mac quickly and elegantly. ![Open-Source Software][OSS Icon]
+- [Spectacle](http://spectacleapp.com/) - Easily organize windows without using a mouse. ![Open-Source Software][OSS Icon]
 - [TextExpander](https://smilesoftware.com/TextExpander/index.html) - Create custom keyboard shortcuts for frequently-used text and pictures.
 
 
 ### Sharing files
 
 - [Cloudapp](https://www.getcloudapp.com/) - Capture and share files and screenshots instantly.
-- [Mac2Imgur](https://github.com/mileswd/mac2imgur) - Upload images and screenshots to Imgur. ![Open-Source Software](media/oss.png)
+- [Mac2Imgur](https://github.com/mileswd/mac2imgur) - Upload images and screenshots to Imgur. ![Open-Source Software][OSS Icon]
 
 
 ### Terminal
 
-- [iTerm2](https://www.iterm2.com/) - A terminal emulator. ![Open-Source Software](media/oss.png)
-- [TotalTerminal](http://totalterminal.binaryage.com/) - A system-wide terminal available on a hot-key. ![Open-Source Software](media/oss.png)
+- [iTerm2](https://www.iterm2.com/) - A terminal emulator. ![Open-Source Software][OSS Icon]
+- [TotalTerminal](http://totalterminal.binaryage.com/) - A system-wide terminal available on a hot-key. ![Open-Source Software][OSS Icon]
 
 
 ### Utilities
 
 - [1Password](https://itunes.apple.com/in/app/1password-password-manager/id443987910?mt=12) - Password Manager and Secure Wallet.
 - [Amphetamine](https://itunes.apple.com/app/amphetamine/id937984704) - Prevents OS X from automatically going to sleep, with lots of configurations.
-- [AnyBar](https://github.com/tonsky/AnyBar) - A menubar status indicator. ![Open-Source Software](media/oss.png)
+- [AnyBar](https://github.com/tonsky/AnyBar) - A menubar status indicator. ![Open-Source Software][OSS Icon]
 - [DaisyDisk](http://www.daisydiskapp.com/) - Analyze disk usage and free up disk space.
-- [Finicky](https://johnste.github.io/finicky/) - App that allows you to set rules that decide which browser is opened for every link. ![Open-Source Software](media/oss.png)
-- [Helium](http://heliumfloats.com/) - A floating browser window that allows you to watch media while you work. ![Open-Source Software](media/oss.png)
+- [Finicky](https://johnste.github.io/finicky/) - App that allows you to set rules that decide which browser is opened for every link. ![Open-Source Software][OSS Icon]
+- [Helium](http://heliumfloats.com/) - A floating browser window that allows you to watch media while you work. ![Open-Source Software][OSS Icon]
 - [iStat Menus](https://bjango.com/mac/istatmenus/) - An advanced system monitor for your menubar.
-- [Keka](http://www.kekaosx.com/en/) - Compress to and extract from many archive file formats. ![Open-Source Software](media/oss.png)
-- [Mackup](https://github.com/lra/mackup) - Keep your application settings in sync. ![Open-Source Software](media/oss.png)
+- [Keka](http://www.kekaosx.com/en/) - Compress to and extract from many archive file formats. ![Open-Source Software][OSS Icon]
+- [Mackup](https://github.com/lra/mackup) - Keep your application settings in sync. ![Open-Source Software][OSS Icon]
 - [Monodraw](http://monodraw.helftone.com/) - A powerful ASCII art editor.
 - [Subtitles](http://subtitlesapp.com/) - Automatically downloads subtitles for your movies and TV shows.
-- [TheUnarchiver](http://wakaba.c3.cx/s/apps/unarchiver.html) - Unarchive many different kinds of archive files. ![Open-Source Software](media/oss.png)
+- [TheUnarchiver](http://wakaba.c3.cx/s/apps/unarchiver.html) - Unarchive many different kinds of archive files. ![Open-Source Software][OSS Icon]
 
 
 ### Others
 
-- [Catch](http://www.giorgiocalderolla.com/index.html#catch) - The easiest way to use ShowRSS. ![Open-Source Software](media/oss.png)
-- [gInbox](https://github.com/chenasraf/gInbox) - gInbox is a wrapper made for Mac around Inbox by Gmail. ![Open-Source Software](media/oss.png)
-- [Hacky](http://www.hackyapp.com/) - Hacky provides browsing Hacker News in a clean and minimalistic way. ![Open-Source Software](media/oss.png)
-- [mpv](http://mpv.io/) - Media player. ![Open-Source Software](media/oss.png)
-- [Sonora](http://getsonora.com/) -  A minimal, beautifully designed music player for the Mac. ![Open-Source Software](media/oss.png)
-- [soundcleod](http://soundcleod.com/) - A browser for SoundCloud. ![Open-Source Software](media/oss.png)
+- [Catch](http://www.giorgiocalderolla.com/index.html#catch) - The easiest way to use ShowRSS. ![Open-Source Software][OSS Icon]
+- [gInbox](https://github.com/chenasraf/gInbox) - gInbox is a wrapper made for Mac around Inbox by Gmail. ![Open-Source Software][OSS Icon]
+- [Hacky](http://www.hackyapp.com/) - Hacky provides browsing Hacker News in a clean and minimalistic way. ![Open-Source Software][OSS Icon]
+- [mpv](http://mpv.io/) - Media player. ![Open-Source Software][OSS Icon]
+- [Sonora](http://getsonora.com/) -  A minimal, beautifully designed music player for the Mac. ![Open-Source Software][OSS Icon]
+- [soundcleod](http://soundcleod.com/) - A browser for SoundCloud. ![Open-Source Software][OSS Icon]
 - [Transmit](https://panic.com/transmit/) - A FTP client.
-- [vienna-rss](https://github.com/ViennaRSS/vienna-rss) - RSS/Atom newsreader. ![Open-Source Software](media/oss.png)
+- [vienna-rss](https://github.com/ViennaRSS/vienna-rss) - RSS/Atom newsreader. ![Open-Source Software][OSS Icon]
 
 
 ## OS X Utilities
@@ -195,3 +195,5 @@ Contributions are most welcome, try to adhere to the [contribution guidelines](c
 [![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)](http://creativecommons.org/licenses/by/4.0/)
 
 This work is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/).
+
+[OSS Icon]: media/oss.png


### PR DESCRIPTION
This makes it easier to change the URL of the icon later.

Reference (pun intended) - https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet