### PR TITLE
Add Subler to Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@
 
 - [mpv](http://mpv.io/) - Media player. [![Open-Source Software][OSS Icon]](https://github.com/mpv-player/mpv)
 - [ScreenFlow](http://www.telestream.net/screenflow/) - Screencasting and video editing software.
+- [Subler](https://bitbucket.org/galad87/subler/wiki/Home) - Mux and tag MP4 files. [![Open-Source Software][OSS Icon]](https://bitbucket.org/galad87/subler/wiki/Home)
 
 
 ### Others


### PR DESCRIPTION
Subler is an Mac OS X app created to mux and tag mp4 files. The main features includes:

- Creation of tx3g subtitles tracks, compatible with all Apple's devices (iPod, AppleTV, iPhone, QuickTime).
- Mux video, audio, chapters, subtitles and closed captions tracks from mov, mp4 and mkv.
- Raw formats: H.264 Elementary streams (.h264, .264), AAC (.aac), AC3 (.ac3), Scenarist (.scc), VobSub (.idx).
- metadata editing and TMDb, TVDB and iTunes Store support.