### PR TITLE
Add XLD to Audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 ### Audio
 
 - [Audacity](http://audacityteam.org/) - Free, open source, cross-platform software for recording and editing sounds. [![Open-Source Software][OSS Icon]](https://github.com/audacity/audacity)
+- [XLD](http://tmkk.undo.jp/xld/index_e.html) - Rip/Decode/convert/play various "lossless" audio files. [![Open-Source Software][OSS Icon]](https://code.google.com/p/xld/source/checkout)
 
 
 ### Chat Clients


### PR DESCRIPTION
Although this application hasn't been updated in a while, it doesn't need to as it's fairly complete. It's the best CD ripper/audio converter I have come across.

X Lossless Decoder(XLD) is a tool for Mac OS X that is able to decode/convert/play various 'lossless' audio files. The supported audio files can be split into some tracks with cue sheet when decoding. It works on Mac OS X 10.4 and later.