### PR TITLE
Update Cake brew main link to website

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@
 ### Developers
 
 - [Base 2](http://menial.co.uk/base/) - A GUI for managing SQLite databases.
-- [Cakebrew](https://github.com/brunophilipe/Cakebrew) - The Homebrew GUI App. [![Open-Source Software][OSS Icon]](https://github.com/brunophilipe/Cakebrew)
+- [Cakebrew](https://www.cakebrew.com/) - The Homebrew GUI App. [![Open-Source Software][OSS Icon]](https://github.com/brunophilipe/Cakebrew)
 - [Charles](http://www.charlesproxy.com) - Charles is a Proxy that allow you to view all of the HTTP and HTTPS traffic.
 - [Dash](https://kapeli.com/dash) - An API Documentation Browser and Code Snippet Manager.
 - [Gas Mask](https://github.com/2ndalpha/gasmask) - A simple hosts file manager which allows editing of host files and switching between them. [![Open-Source Software][OSS Icon]](https://github.com/2ndalpha/gasmask)


### PR DESCRIPTION
As per your contribution guidelines:
> the primary link for the application should point to the application's __website__.

In the case of Cake brew the main link directed to the github page for cakebrew, as oppose to the cakebrew website [https://www.cakebrew.com/] (https://www.cakebrew.com/).