### PR TITLE
Fixed el capitan # tag so setup link points to correct area of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 - [Setup](#setup)
     - [OS X 10.9 Mavericks](#os-x-109-mavericks-setup)
     - [OS X 10.10 Yosemite](#os-x-1010-yosemite-setup)
-    - [OS X 10.11 El Capitan](#os-x-1011-elcapitan-setup)
+    - [OS X 10.11 El Capitan](#os-x-1011-el-capitan-setup)
 - [Security](#security)
 - [Miscellaneous](#miscellaneous)
 - [Discussion Forums](#discussion-forums)


### PR DESCRIPTION
Due to space in El Capitan OS needed to add an extra dash to CSS inline link to correct point to area of our README file. Inline link now functions correctly, pointing to correct area of page when clicked.