### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@
 - [Hosts](https://github.com/specialunderwear/Hosts.prefpane) - Edit hosts file. [![Open-Source Software][OSS Icon]](https://github.com/specialunderwear/Hosts.prefpane)
 - [ImageAlpha](https://pngmini.com/) - Apply lossy compression on PNG files with or without transparency for more efficient files. [![Open-Source Software][OSS Icon]](https://github.com/pornel/ImageAlpha)
 - [ImageOptim](https://imageoptim.com/) - Makes images take up less disk space and load faster. [![Open-Source Software][OSS Icon]](https://github.com/pornel/ImageOptim)
-- [Insomnia](http://insomnia.rest) - A modern REST client with an beautiful interface.
+- [Insomnia](http://insomnia.rest) - A modern REST client with a beautiful interface.
 - [Integrity](http://peacockmedia.software/mac/integrity/free.html) - Easily find your website's broken links.
 - [Paw](https://luckymarmot.com/paw) - The ultimate REST client.
 - [PSequel](http://www.psequel.com/) - A PostgreSQL GUI tool.
@@ -246,7 +246,7 @@
 - [Subtitles](http://subtitlesapp.com/) - Automatically downloads subtitles for your movies and TV shows.
 - [TeamViewer](https://www.teamviewer.com/en-us/index.aspx) - Remotely control another computer.
 - [TextBar](http://www.richsomerfield.com/apps/) - TextBar is a tiny but powerful app that lets you add any text to your MenuBar.
-- [Typora](http://www.typora.io/) - Another minial Markdown editor.
+- [Typora](http://www.typora.io/) - Another minimal Markdown editor.
 - [Übersicht](http://tracesof.net/uebersicht/) - Run system commands and display their output on your desktop as widgets. [![Open-Source Software][OSS Icon]](https://github.com/felixhageloh/uebersicht)
 - [The Unarchiver](http://unarchiver.c3.cx/unarchiver) - Unarchive many different kinds of archive files. [![Open-Source Software][OSS Icon]](https://bitbucket.org/WAHa_06x36/theunarchiver)
 - [Wineskin](http://wineskin.urgesoftware.com/) - Run Windows applications and games on your Mac. [![Open-Source Software][OSS Icon]](http://sourceforge.net/p/wineskin/code/ci/master/tree/)


### PR DESCRIPTION
Replace `an` with `a`
`minial` → `minimal`