### PR TITLE
Update Neptunes: no longer open source

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 - [Audio Hijack](http://www.rogueamoeba.com/audiohijack/) - Record audio from any application like iTunes, Skype or Safari, or from hardware devices like microphones and mixers.
 - [Cog](http://cogx.org/) - A free open source audio player for OS X. [![Open-Source Software][OSS Icon]](https://bitbucket.org/mamburu/cog/)
 - [Mixxx](http://mixxx.org/) - Free DJ software that gives you everything you need to perform live mixes, veritable alternative to Traktor. [![Open-Source Software][OSS Icon]](https://github.com/mixxxdj/mixxx)
-- [NepTunes](http://micropixels.pl/neptunes/) - reliable and modern Last.fm scrobbler for iTunes. [![Open-Source Software][OSS Icon]](https://github.com/rurza/NepTunes)
+- [NepTunes](http://micropixels.pl/neptunes/) - reliable and modern Last.fm scrobbler for iTunes.
 - [VOX Player](https://coppertino.com/vox/mac) - Play numerous lossy and lossless audio formats.
 - [XLD](http://tmkk.undo.jp/xld/index_e.html) - Rip/Decode/convert/play various "lossless" audio files. [![Open-Source Software][OSS Icon]](https://code.google.com/p/xld/source/checkout)
 


### PR DESCRIPTION
https://github.com/rurza/NepTunes is gone, there is now https://github.com/rurza/NepTunes-Issues