### PR TITLE
Restore Mac OS X Manual Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@
 ## Command Line Utilities
 
 - [Awesome OS X Command Line](https://github.com/herrbischoff/awesome-osx-command-line) - Use your OS X terminal shell to do awesome things.
+- [Mac OS X Manual Pages](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/) - Apple's official man page reference which lists all general commands in Section 1.
 
 ## OS X Utilities
 


### PR DESCRIPTION
Updated link #288