### PR TITLE
Remove MPlayerX

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,6 @@
 ### Video
 
 - [HandBrake](https://handbrake.fr/) - High performance video encoding and conversion tools with a nice GUI. [![Open-Source Software][OSS Icon]](https://github.com/HandBrake/HandBrake)
-- [MPlayerX](http://mplayerx.org) - Media player. [![Open-Source Software][OSS Icon]](https://github.com/niltsh/MPlayerX)
 - [mpv](https://mpv.io/) - Media player. [![Open-Source Software][OSS Icon]](https://github.com/mpv-player/mpv)
 - [ScreenFlow](http://www.telestream.net/screenflow/) - Screencasting and video editing software.
 - [Subler](https://bitbucket.org/galad87/subler/wiki/Home) - Mux and tag MP4 files. [![Open-Source Software][OSS Icon]](https://bitbucket.org/galad87/subler/wiki/Home)


### PR DESCRIPTION
MPlayerX's official installer contains malware/adware. I would argue this isn't _awesome_. I suggest removing it from the list.

https://www.google.com/#q=mplayerx+malware